### PR TITLE
fix: Unauthorized routes will now return 401 instead of 404(NotFound)

### DIFF
--- a/WebApp/backend/QuizMaster.API.Gatewway/Controllers/AccountGatewayController.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Controllers/AccountGatewayController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using QuizMaster.API.Account.Models;
 using QuizMaster.API.Account.Proto;
+using QuizMaster.API.Gateway.Helper;
 using QuizMaster.Library.Common.Entities.Accounts;
 using QuizMaster.Library.Common.Models;
 using System.Globalization;
@@ -33,7 +34,7 @@ namespace QuizMaster.API.Gatewway.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns>Task<IActionResult></returns>
-        [Authorize]
+        [QuizMasterAuthorization]
         [HttpGet("get_account/{id}")]
         public async Task<IActionResult> Get(int id)
         {
@@ -57,7 +58,7 @@ namespace QuizMaster.API.Gatewway.Controllers
         /// Get all account API
         /// </summary>
         /// <returns>Task<IActionResult></returns>
-        [Authorize]
+        [QuizMasterAuthorization]
         [HttpGet("get_all_users")]
         public async Task<IActionResult> GetAllUsers()
         {
@@ -131,7 +132,7 @@ namespace QuizMaster.API.Gatewway.Controllers
             return Ok(reply);
         }
 
-        [Authorize]
+        [QuizMasterAuthorization]
         [HttpDelete("delete/{id}")]
         public async Task<IActionResult> Delete(int id)
         {
@@ -154,7 +155,7 @@ namespace QuizMaster.API.Gatewway.Controllers
             return NoContent();
         }
 
-        [Authorize]
+        [QuizMasterAuthorization]
         [HttpPatch("update/{id}")]
         public async Task<IActionResult> Update(int id, JsonPatchDocument<UserAccount> patch)
         {

--- a/WebApp/backend/QuizMaster.API.Gatewway/Controllers/AuthenticationGatewayController.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Controllers/AuthenticationGatewayController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authentication;
 using QuizMaster.API.Authentication.Helper;
 using Microsoft.AspNetCore.Authorization;
 using Newtonsoft.Json;
+using QuizMaster.API.Gateway.Helper;
 
 namespace QuizMaster.API.Gateway.Controllers
 {
@@ -55,7 +56,7 @@ namespace QuizMaster.API.Gateway.Controllers
             return Ok(new { Message = "Logged in successfully", reply.Token });
         }
 
-        [Authorize]
+        [QuizMasterAuthorization]
         [HttpPost]
         [Route("logout")]
         public async Task<IActionResult> Logout()
@@ -67,7 +68,7 @@ namespace QuizMaster.API.Gateway.Controllers
             return Ok(new { Message = "Logged out successfully" });
         }
 
-        [Authorize]
+        [QuizMasterAuthorization]
         [HttpGet("info")]
         public async Task<IActionResult> GetCookieInfo()
         {
@@ -93,7 +94,7 @@ namespace QuizMaster.API.Gateway.Controllers
             return Ok(new { Message = "Info", info });
         }
 
-        [Authorize]
+        [QuizMasterAuthorization]
         [HttpPost]
         [Route("set_admin/{id}")]
         public IActionResult SetAdmin(int id)

--- a/WebApp/backend/QuizMaster.API.Gatewway/Helper/QuizMasterAuthorizationAttribute.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Helper/QuizMasterAuthorizationAttribute.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace QuizMaster.API.Gateway.Helper
+{
+    public class QuizMasterAuthorizationAttribute : TypeFilterAttribute
+    {
+        public QuizMasterAuthorizationAttribute() : base(typeof(QuizMasterAuthorizationFilter)) { }
+    }
+}

--- a/WebApp/backend/QuizMaster.API.Gatewway/Helper/QuizMasterAuthorizationFilter.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Helper/QuizMasterAuthorizationFilter.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using QuizMaster.API.Authentication.Helper;
+using QuizMaster.API.Authentication.Services.Auth;
+
+namespace QuizMaster.API.Gateway.Helper
+{
+    public class QuizMasterAuthorizationFilter: IAuthorizationFilter
+    {
+        private readonly IAuthenticationServices _authenticationServices;
+        public QuizMasterAuthorizationFilter(IAuthenticationServices authenticationServices)
+        {
+            _authenticationServices = authenticationServices;
+        }
+        public void OnAuthorization(AuthorizationFilterContext context)
+        {
+            // Retrieve the user's principal from the HttpContext
+            var principal = context.HttpContext.User;
+
+            if(principal.Identity == null)
+            {
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+
+            // Check if the user is authenticated
+            if (!principal.Identity.IsAuthenticated)
+            {
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+
+            // Check the cookie for your token claim
+            var tokenClaim = principal.Claims.FirstOrDefault(c => c.Type == "token")?.Value;
+
+            if (string.IsNullOrEmpty(tokenClaim))
+            {
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+
+            // Validate the token as needed
+            if (!IsTokenValid(tokenClaim, context.HttpContext))
+            {
+                context.Result = new UnauthorizedResult();
+            }
+        }
+
+        private bool IsTokenValid(string token, HttpContext httpContext)
+        {
+            // validate the token
+            var authStore = _authenticationServices.Validate(token);
+
+            // if auth store is null, the token specified failed to decode
+            if (authStore == null)
+                return false;
+
+            // if the token expired, return false
+            if (authStore.IsExpired())
+                return false;
+
+            // If token is valid, return true; otherwise, return false.
+            return true;
+        }
+    }
+}

--- a/WebApp/backend/QuizMaster.API.Gatewway/Program.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Program.cs
@@ -1,5 +1,11 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using QuizMaster.API.Authentication.Configuration;
 using QuizMaster.API.Authentication.Helper;
+using QuizMaster.API.Authentication.Services;
+using QuizMaster.API.Authentication.Services.Auth;
+using QuizMaster.API.Authentication.Services.GRPC;
+using QuizMaster.API.Authentication.Services.Temp;
+using QuizMaster.API.Authentication.Services.Worker;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,21 +19,31 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddControllers().AddNewtonsoftJson();
 
+// Configuring strongly typed settings object
+builder.Services.Configure<AppSettings>(builder.Configuration.GetSection("AppSettings"));
+
+// register the services
+builder.Services.AddScoped<IRepository, Repository>();
+builder.Services.AddScoped<RabbitMqUserWorker>();
+builder.Services.AddScoped<IAuthenticationServices, AuthenticationServices>();
+builder.Services.AddSingleton<RabbitMqRepository>();
+
+
 // configure cookie authentication
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                .AddCookie(option =>
-                {
-                    option.Events = new CookieAuthenticationEvents
-                    {
-                        OnValidatePrincipal = async (context) =>
-                        {
-                            // validate the cookie
-                            await CookieHelper.ValidateCookie(context, builder.Configuration["AppSettings:JWTSecret"]);
-                        }
-                    };
-                    option.ExpireTimeSpan = TimeSpan.FromHours(Convert.ToInt16(builder.Configuration["AppSettings:IntExpireHour"]));
-                    option.SlidingExpiration = true; // renew cookie when it's about to expire,
-                });
+    .AddCookie(option =>
+    {
+        option.Events = new CookieAuthenticationEvents
+        {
+            OnValidatePrincipal = async (context) =>
+            {
+                // validate the cookie
+                await CookieHelper.ValidateCookie(context, builder.Configuration["AppSettings:JWTSecret"]);
+            }
+        };
+        option.ExpireTimeSpan = TimeSpan.FromHours(Convert.ToInt16(builder.Configuration["AppSettings:IntExpireHour"]));
+        option.SlidingExpiration = true; // renew cookie when it's about to expire,
+    });
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Fixed Unauthorized Routes returning 404
This bugfix solved the issue #23 
If a request without cookie is accessing a route that require authentication, we can now expect that it should return 401 (Unauthorized) instead of 404 (NotFound)