### PR TITLE
Fix: Incorrect Behavior in the Login Process - Potential Relationship to Trello Ticket #53

### DIFF
--- a/WebApp/backend/QuizMaster.API.Authentication/Services/RabbitMqRepository.cs
+++ b/WebApp/backend/QuizMaster.API.Authentication/Services/RabbitMqRepository.cs
@@ -43,21 +43,28 @@ namespace QuizMaster.API.Authentication.Services
 
         public RabbitMQ_AccountPayload TryGetCache(AuthRequest authRequest)
         {
+            RabbitMQ_AccountPayload? accountPayload = null;
             foreach (var (k, v) in users)
             {
                 if (v.Account == null)
                     continue;
                 if (v.Account.UserName != null)
                     if (v.Account.UserName.ToLower() == authRequest.Username.ToLower())
-                        return v;
+                        accountPayload = v;
                 if (v.Account.Email != null)
                     if (v.Account.Email.ToLower() == authRequest.Email.ToLower())
-                        return v;
+                        accountPayload = v;
                 // try parsing the username to Id
                 _ = Int32.TryParse(authRequest.Username, out int Id);
                 if (Id != 0)
                     if (Id == k)
-                        return v;
+                        accountPayload = v;
+            }
+
+            if( accountPayload != null)
+            {
+                users.Remove(accountPayload.Account.Id);
+                return accountPayload;
             }
 
             return new() { Account = new UserAccount { Id = -1 }, Roles = new List<string>() };


### PR DESCRIPTION
### Bug Description
Upon investigation, it appears that there is an issue with the login process in the Authentication Gateway. Specifically, when attempting to log in with an admin account and providing an incorrect password, a token is generated despite the incorrect credentials. Additionally, logging in with a user account using the correct credentials leads to a runtime error or breakpoint in the getUser method.

### Steps to Reproduce:

1. Log in with the admin account and provide an incorrect password.
2. Observe that a token is generated despite the incorrect password.
3. Log in with a user account using the correct credentials.
4. Observe the runtime error or breakpoint in the getUser method.

### Expected Behavior: 
The system should not generate a token for the admin account with incorrect credentials. Logging in with the correct user credentials should not result in a runtime error or breakpoint in the getUser method.

### Additional Information:

Endpoint: gateway/api/auth/login
Method: POST
Request Payload: `{ "username": "exampleUser", "password": "correctPassword" }`

### Comments
fixed, the issue is that I cached the old token and then when being requested again, it will return what’s cached disregarding the password. I changed the behavior by deleting what’s cached after being used.