### PR TITLE
Session Patches

### DIFF
--- a/WebApp/backend/QuizMaster.API.Account/Service/Worker/RabbitMqUserWorker.cs
+++ b/WebApp/backend/QuizMaster.API.Account/Service/Worker/RabbitMqUserWorker.cs
@@ -142,12 +142,28 @@ namespace QuizMaster.API.Account.Service.Worker
             if(userAccount == null)
                 return new() { Id = -1 };
 
-            // Compare user password
-            PasswordHasher<UserAccount> hasher = new();
+            // Partial Account
+            if(request.Password == "System.Partial.Account" && string.IsNullOrEmpty(userAccount.PasswordHash))
+            {
+                if(string.IsNullOrEmpty(userAccount.FirstName) && string.IsNullOrEmpty(userAccount.LastName))
+                {
+                    string tempUser = "User-" + new Random().Next(1000000, 9999999).ToString();
+                    userAccount.FirstName = tempUser;
+                    userAccount.LastName = tempUser;
+                }
+                else { return new() { Id = -1 }; };
+            }
+            // With Password
+            else
+            {
+                // Compare user password
+                PasswordHasher<UserAccount> hasher = new();
 
-            // check if password is correct
-            var passwordVerification = hasher.VerifyHashedPassword(userAccount, userAccount.PasswordHash, request.Password);
-            if (PasswordVerificationResult.Success != passwordVerification) { return new() { Id = -1 }; };
+                // check if password is correct
+                var passwordVerification = hasher.VerifyHashedPassword(userAccount, userAccount.PasswordHash, request.Password);
+                if (PasswordVerificationResult.Success != passwordVerification) { return new() { Id = -1 }; };
+            }
+            
 
             return userAccount;
         }

--- a/WebApp/backend/QuizMaster.API.Authentication/Models/AuthenticationRequestDTO.cs
+++ b/WebApp/backend/QuizMaster.API.Authentication/Models/AuthenticationRequestDTO.cs
@@ -29,4 +29,16 @@ namespace QuizMaster.API.Authentication.Models
             return new AuthRequest { Email = Email, Password = Password, Username = Username, Type = "Credentials" };
         }
     }
+
+    public class PartialAuthenticationRequest
+    {
+        /// <summary>
+        /// **Username**(Optional when Email exists): Authenticatate with using the user's Username
+        /// </summary>
+        public string Username { get; set; } = string.Empty;
+        /// <summary>
+        /// **Email**(Optional when Username exists): Authenticatate with using the user's Email
+        /// </summary>
+        public string Email { get; set; } = string.Empty;
+    }
 }

--- a/WebApp/backend/QuizMaster.API.Gatewway/Controllers/AuthenticationGatewayController.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Controllers/AuthenticationGatewayController.cs
@@ -66,6 +66,12 @@ namespace QuizMaster.API.Gateway.Controllers
             return Ok(new { Message = "Logged in successfully", reply.Token });
         }
 
+        [HttpPost("partialLogin")]
+        public async Task<IActionResult> LoginPartial([FromBody] PartialAuthenticationRequest requestModel)
+        {
+            return await Login(new AuthenticationRequestDTO { Email = requestModel.Email, Username = requestModel.Username, Password = "System.Partial.Account" });
+        }
+
         [QuizMasterAuthorization]
         [HttpPost]
         [Route("logout")]

--- a/WebApp/backend/QuizMaster.API.Gatewway/Controllers/QuizSetGatewayController.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Controllers/QuizSetGatewayController.cs
@@ -39,7 +39,7 @@ namespace QuizMaster.API.Gateway.Controllers
             _channel = GrpcChannel.ForAddress(options.Value.Session_Service, new GrpcChannelOptions { HttpHandler = handler });
             roomChannelClient = new QuizRoomService.QuizRoomServiceClient(_channel);
             SessionHandler = sessionHandler;
-            _authChannel = GrpcChannel.ForAddress(options.Value.Authentication_Service);
+            _authChannel = GrpcChannel.ForAddress(options.Value.Authentication_Service, new GrpcChannelOptions { HttpHandler = handler });
             _authChannelClient = new AuthService.AuthServiceClient(_authChannel);
         }
 

--- a/WebApp/backend/QuizMaster.API.Gatewway/Hubs/SessionHub.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Hubs/SessionHub.cs
@@ -54,6 +54,7 @@ namespace QuizMaster.API.Gateway.Hubs
         {
             var connectionId = Context.ConnectionId;
             await SessionHandler.AuthenticateConnectionId(this, _authChannelClient, connectionId, token);
+            await GetConnectionId(); // return connectionId
         }
 
         public async Task CreateRoom(CreateRoomDTO roomDTO)

--- a/WebApp/backend/QuizMaster.API.Gatewway/Services/SessionHandler.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Services/SessionHandler.cs
@@ -60,15 +60,18 @@ namespace QuizMaster.API.Gateway.Services
                 connectionGroupPair.Remove(connectionId);
             }
         }
-        public async Task RemoveClientFromGroups(SessionHub hub, string connectionId, string disconnectMessage, string channel = "chat")
+        public async Task RemoveClientFromGroups(SessionHub hub, string connectionId, string disconnectMessage, string channel = "chat", bool sendParticipantData = true)
         {
             if (connectionGroupPair.ContainsKey(connectionId))
             {
                 await hub.Groups.RemoveFromGroupAsync(connectionId, connectionGroupPair[connectionId]);
                 await hub.Clients.Group(connectionGroupPair[connectionId]).SendAsync(channel, new { Message = disconnectMessage, Name = "bot", IsAdmin = false });
 
-                IEnumerable<object> participants = GetParticipantLinkedConnectionsInAGroup(connectionGroupPair[connectionId]).Select(p => new { p.UserId, p.QParticipantDesc });
-                await hub.Clients.Group(connectionGroupPair[connectionId]).SendAsync("participants", participants);
+                if (sendParticipantData)
+                {
+                    IEnumerable<object> participants = GetParticipantLinkedConnectionsInAGroup(connectionGroupPair[connectionId]).Select(p => new { p.UserId, p.QParticipantDesc });
+                    await hub.Clients.Group(connectionGroupPair[connectionId]).SendAsync("participants", participants);
+                }
 
                 connectionGroupPair.Remove(connectionId);
                 


### PR DESCRIPTION
# Session Patches
This update includes the Following:
- Fixed bug on participants list not updating when a certain user has left the room or got disconnected
- Fixed SessionHub to fail with gRPC error [Invalid SSL Certificate]
- New Feature Login Partial Account
  - This feature is only accessible to partial accounts. When a user with 'Full' account tries to login in the `partial-login` route, they should not be able to pass.

Partial Login route: `{BASE_URL}:7081/gateway/api/auth/partialLogin`

Example:
lets say we have 2 users in the system
- Jay [partial user]
- JM [full detailed user]
routes:
#### Login Route
-  JM can login provided his `username` or `email` and `password` | A token was generated
-  Jay cannot proceed, since he is a partial user | No token was generated
#### Partial Login Route
- JM cannot proceed, since he is a full user, he should use the login route that Includes password | No token was generated
- Jay can login provided his `username` or `email` with ease | A token was generated
#### Get Information
- JM's information will be decoded in the token
- Jay's information will be different, his lastname and firstname will be `User-{RandomNumber}` since both properties are null on partial account