### PR TITLE
Feat: Added Metadata for QuizSession In-Game

### DIFF
--- a/WebApp/backend/QuizMaster.API.Gatewway/Services/QuizHandler.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Services/QuizHandler.cs
@@ -65,7 +65,7 @@ namespace QuizMaster.API.Gateway.Services
 
                 if (Setquestions == null) continue;
 
-
+                int currentQuestion = 1;
                 foreach (var questionSet in Setquestions)
                 {
                     roomPin = Qset.QRoom.QRoomPin + "";
@@ -88,6 +88,22 @@ namespace QuizMaster.API.Gateway.Services
                     details.CurrentSetName = questionSet.Set.QSetName;
                     details.CurrentSetDesc = questionSet.Set.QSetDesc;
                     details.details.ForEach(qD => qD.DetailTypes = new List<DetailType>());
+
+                    /*
+                     * Room Metadata
+                     * - CurrentSet
+                     * - TotalNumberOfSets
+                     * - CurrentQuestion
+                     * - TotalNumberOfQuestions
+                     * - ParticipantsInRoom
+                     */
+                    await hub.Clients.Group(roomPin).SendAsync("metadata", new {
+                        currentSet = setIndex + 1,
+                        totalNumberOfSets = quizSets.Count,
+                        currentQuestion = currentQuestion++,
+                        totalNumberOfQuestions = Setquestions.Count,
+                        participantsInRoom = handler.GetParticipantLinkedConnectionsInAGroup(roomPin).Count(),
+                    });
 
                     for (int time = timout; time >= 0; time--)
                     {

--- a/WebApp/backend/QuizMaster.API.Gatewway/Services/QuizHandler.cs
+++ b/WebApp/backend/QuizMaster.API.Gatewway/Services/QuizHandler.cs
@@ -91,16 +91,20 @@ namespace QuizMaster.API.Gateway.Services
 
                     /*
                      * Room Metadata
-                     * - CurrentSet
+                     * - CurrentSetIndex
+                     * - CurrentSetName
                      * - TotalNumberOfSets
-                     * - CurrentQuestion
+                     * - CurrentQuestionIndex
+                     * - CurrentQuestionName
                      * - TotalNumberOfQuestions
                      * - ParticipantsInRoom
                      */
                     await hub.Clients.Group(roomPin).SendAsync("metadata", new {
-                        currentSet = setIndex + 1,
+                        currentSetName = details.CurrentSetName,
+                        currentSetIndex = setIndex + 1,
                         totalNumberOfSets = quizSets.Count,
-                        currentQuestion = currentQuestion++,
+                        currentQuestionIndex = currentQuestion++,
+                        currentQuestionName = details.question.QStatement,
                         totalNumberOfQuestions = Setquestions.Count,
                         participantsInRoom = handler.GetParticipantLinkedConnectionsInAGroup(roomPin).Count(),
                     });


### PR DESCRIPTION
## Room Metadata included in the In-Game session
While the In-Game session is started, it's hard to know how many participants in the room, current set displayed, total number of sets, current question, total number of questions, since we are only displaying `question` 

I have included a `metadata` method that will be invoked on the frontend that will contain the following:
- CurrentSetIndex
- CurrentSetName
- TotalNumberOfSets
- CurrentQuestionIndex
- CurrentQuestionName
- TotalNumberOfQuestions
- ParticipantsInRoom

![Figure](https://media.giphy.com/media/xULW8INGrA62E85Wdq/giphy.gif)